### PR TITLE
fix: set path to fieldName for resolver(#19)

### DIFF
--- a/jest/common/parent.model.ts
+++ b/jest/common/parent.model.ts
@@ -1,8 +1,8 @@
 import { Connection, Document, Model, Schema } from 'mongoose';
 
-export function getParentModel(connection: Connection, child: Model<Document>) {
+export function getParentModel(connection: Connection, child: Model<Document>, _name?: string) {
 
-  const name = 'ParentModel';
+  const name = _name || 'ParentModel';
   if (connection.modelNames().includes(name)) return connection.model(name);
 
   const ParentSchema = new Schema({
@@ -12,5 +12,5 @@ export function getParentModel(connection: Connection, child: Model<Document>) {
     }
   });
 
-  return connection.model('ParentModel', ParentSchema);
+  return connection.model(name, ParentSchema);
 }

--- a/jest/common/simple.model.ts
+++ b/jest/common/simple.model.ts
@@ -1,8 +1,8 @@
 import { Connection, Schema } from 'mongoose';
 
-export function getSimpleModel(connection: Connection) {
+export function getSimpleModel(connection: Connection, _name?: string) {
 
-  const name = 'SimpleModel';
+  const name = _name || 'SimpleModel';
   if (connection.modelNames().includes(name)) return connection.model(name);
 
   const SimpleSchema = new Schema({

--- a/jest/tc-complex-ref.ts
+++ b/jest/tc-complex-ref.ts
@@ -74,6 +74,9 @@ export function complexRefCase(connection: Connection): ComplexRefTestCase {
     }
   });
 
+  const ClonedSchema = BazSchema.clone()
+  ComplexRefParentSchema.add({clones: [ClonedSchema]})
+
   const simpleModel = getSimpleModel(connection);
   simpleModel.discriminator(childModelName, ComplexRefChildSchema);
 

--- a/jest/tc-multiple.ts
+++ b/jest/tc-multiple.ts
@@ -1,0 +1,85 @@
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { Connection, Document, Model, models } from 'mongoose';
+import { getParentModel } from './common/parent.model';
+import { getSimpleModel } from './common/simple.model';
+import { simpleResponse } from './common/simple.response';
+import { SimpleType } from './common/simple.type';
+import { TestCase } from './tc';
+
+interface MultipleTestCase extends Omit<TestCase, 'model'> {
+  firstModel: Model<Document>
+  secondModel: Model<Document>
+  firstParentModelName:string
+  secondParentModelName:string
+  firstChildModelName:string
+  secondChildModelName:string
+}
+
+/**
+ * A Ref Test Case.
+ *
+ * @param connection        Mongoose Connection
+ * @returns                 Test Case
+ */
+export function multipleCase(connection: Connection): MultipleTestCase {
+
+  const firstSimpleModel = getSimpleModel(connection, 'first');
+  const firstChildModelName = firstSimpleModel.modelName;
+  const firstModel = getParentModel(connection, firstSimpleModel, 'FirstParent');
+  const firstParentModelName = firstModel.modelName;
+
+  const secondSimpleModel = getSimpleModel(connection, 'second');
+  const secondChildModelName = secondSimpleModel.modelName;
+  const secondModel = getParentModel(connection, secondSimpleModel, 'SecondParent');
+  const secondParentModelName = secondModel.modelName;
+
+  const response = {
+    child: { ...simpleResponse }
+  };
+
+  const FirstType: GraphQLObjectType = new GraphQLObjectType({
+    name: 'FirstType',
+    fields: () => ({
+      child: {
+        type: SimpleType
+      }
+    })
+  });
+
+  const SecondType: GraphQLObjectType = new GraphQLObjectType({
+    name: 'SecondType',
+    fields: () => ({
+      child: {
+        type: SimpleType
+      }
+    })
+  });
+
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'MultipleQueries',
+      fields: () => ({
+        first: {
+          type: FirstType,
+          resolve: () => response
+        },
+        second: {
+          type: SecondType,
+          resolve: () => response
+        }
+      })
+    })
+  });
+
+
+  return {
+    firstModel,
+    secondModel,
+    response,
+    schema,
+    firstParentModelName,
+    secondParentModelName,
+    firstChildModelName,
+    secondChildModelName
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicky-lenaers/mogr",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MoGr dynamically maps GraphQL AST's to Mongoose Query Projection and/or Population and provides GraphQL Cursor Pagination.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -183,6 +183,10 @@ export class Registry {
     fields: PopulatableField[] = []
   ): PopulatableField[] {
 
+    if (!type) {
+      return []
+    }
+
     if (type.ref && typeof type.ref === 'string') {
 
       if (!fields.map(field => field.path).includes(path)) {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -184,7 +184,7 @@ export class Registry {
   ): PopulatableField[] {
 
     if (!type) {
-      return []
+      return fields
     }
 
     if (type.ref && typeof type.ref === 'string') {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -111,9 +111,12 @@ export class Registry {
    */
   private _getSelections(info: GraphQLResolveInfo, root: string) {
 
-    const operationSelection: SelectionSetNode =
-      (info.operation.selectionSet.selections[0] as FieldNode)
-        .selectionSet as SelectionSetNode;
+    const operationSelection: SelectionSetNode = root
+      ? ((info.operation.selectionSet.selections[0] as FieldNode)
+          .selectionSet as SelectionSetNode)
+      : ((info.operation.selectionSet.selections.find(
+          selection => (selection as FieldNode).name.value === info.fieldName
+        ) as FieldNode).selectionSet as SelectionSetNode);
 
     return this._getSelectionsOffsetByPath(
       operationSelection,


### PR DESCRIPTION
Fixes #19
Fixes #21 

When no root path is specified, registry should pick up the top-level fieldName from `info` to infer the path of the resolver.

I added a test for this and it also works against my rather large mongoose+graphql backend with E2E tests.

Looking forward to getting this merged 👍 lmk if there's anything missing. Btw, I appreciate the api design and cleanliness of this repo. Big ups